### PR TITLE
feat: add rule to report on bad chunk permissions

### DIFF
--- a/src/doctor/rules/index.py
+++ b/src/doctor/rules/index.py
@@ -12,5 +12,5 @@ from . import rule
 
 @rule(__name__)
 def unused(cursor):
-  """Index {indexrelname} on table {relname} is not used: consider removing it and saving {index_size}."""
+  """Index '{indexrelname}' on table '{relname}' is not used: consider removing it and saving {index_size}."""
   cursor.execute(QUERY)


### PR DESCRIPTION
If the parent hypertable and its chunks have different permissions, it usually creates problems for some queries. This rule finds all chunks that have mismatching permissions compared to the hypertable.

Fixed #3 