### PR TITLE
chore: fix version bump in release-please

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def get_version(rel_path: str) -> str:
 
 setup(
     name = "timescale-doctor",
-    version = get_version("src/doctor/__init__.py"),
+    version = get_version("src/doctor/version.py"),
     author = "Mats Kindahl",
     author_email = "mats@timescale.com",
     description ="Analyze a database and provide recommendations",

--- a/src/doctor/__init__.py
+++ b/src/doctor/__init__.py
@@ -88,5 +88,3 @@ def check_rules(dbname, user, host, port):
                     header_printed = True
                 clean = dedent(report)
                 print(fill(clean, initial_indent="- ", subsequent_indent="  "))
-
-__version__ = "0.0.1"

--- a/src/doctor/version.py
+++ b/src/doctor/version.py
@@ -1,0 +1,3 @@
+"""Defines the version of timescale-doctor"""
+# Do not remove this file, release-please needs it
+__version__ = "0.0.1"


### PR DESCRIPTION
It turns out that release-please expects that the version is defined in a file named "version.py" and will not bump the version otherwise.