### PR TITLE
fix: only check permission for existing chunks

### DIFF
--- a/src/doctor/rules/hypertable.py
+++ b/src/doctor/rules/hypertable.py
@@ -60,7 +60,8 @@ WITH tables AS (
            format('%I.%I', ch.schema_name, ch.table_name)::regclass as chunk
       FROM _timescaledb_catalog.hypertable ht
       JOIN _timescaledb_catalog.chunk ch
-        ON ch.hypertable_id = ht.id)
+        ON ch.hypertable_id = ht.id
+     WHERE NOT dropped)
 SELECT hypertable,
        chunk
   FROM tables

--- a/src/doctor/rules/hypertable_test.py
+++ b/src/doctor/rules/hypertable_test.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Timescale, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for compressed hypertable rules."""
+
+from os.path import join, dirname
+
+from doctor.rules.hypertable import ChunkPermissions
+from doctor.unittest import TimescaleDBTestCase
+
+class TestHypertableRules(TimescaleDBTestCase):
+    """Test hypertable rules."""
+
+    def setUp(self):
+        """Set up unit tests for hypertable rules."""
+        print(__file__)
+        fname = join(dirname(__file__), "sql/setup.hypertable_test.sql")
+        with self.connection.cursor() as cursor, open(fname, "r", encoding="ascii") as infile:
+            cursor.execute(infile.read())
+
+    def tearDown(self):
+        """Tear down compression rules test."""
+        fname = join(dirname(__file__), "sql/teardown.hypertable_test.sql")
+        with self.connection.cursor() as cursor, open(fname, "r", encoding="ascii") as infile:
+            cursor.execute(infile.read())
+
+    def test_chunk_permissions(self):
+        """Test chunk permission rule."""
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT chunk FROM show_chunks(%s) AS chunk ORDER BY chunk LIMIT 1",
+                ('conditions',)
+            )
+            row = cursor.fetchone()
+            self.assertIsNotNone(row)
+            cursor.execute(f"REVOKE SELECT ON {row['chunk']} FROM PUBLIC")
+        messages = []
+        messages.extend(self.run_rule(ChunkPermissions()))
+        message = ChunkPermissions.message.format(chunk=row['chunk'], hypertable="conditions")
+        self.assertIn(message, messages)

--- a/src/doctor/rules/sql/setup.hypertable_test.sql
+++ b/src/doctor/rules/sql/setup.hypertable_test.sql
@@ -1,0 +1,26 @@
+CREATE TABLE conditions(
+    time TIMESTAMPTZ NOT NULL,
+    device INTEGER,
+    temperature FLOAT
+);
+
+SELECT * FROM create_hypertable('conditions', 'time', chunk_time_interval => INTERVAL '1 day');
+
+INSERT INTO conditions
+SELECT time, (random()*30)::int, random()*80 - 40
+FROM generate_series(now() - '1 month'::interval,
+     		     now(),
+		     INTERVAL '1 min') AS time;
+
+CREATE MATERIALIZED VIEW conditions_summary_hourly
+WITH (timescaledb.continuous) AS
+SELECT device,
+       time_bucket('1 hour', "time") AS bucket,
+       AVG(temperature),
+       MAX(temperature),
+       MIN(temperature)
+FROM conditions
+GROUP BY device, bucket
+WITH NO DATA;
+
+SELECT drop_chunks('conditions', now() - '2 weeks'::interval);

--- a/src/doctor/rules/sql/teardown.hypertable_test.sql
+++ b/src/doctor/rules/sql/teardown.hypertable_test.sql
@@ -1,0 +1,2 @@
+DROP MATERIALIZED VIEW conditions_summary_hourly;
+DROP TABLE conditions;


### PR DESCRIPTION
If the `dropped` flag is set for a chunk the real chunk is dropped but still present in the catalog. This leads to errors in the `ChunkPermission` rule since it tries to check ACL for a non-existing relation.

Fixes #26