### PR TITLE
fix: endswith accepts tuples or string, not list

### DIFF
--- a/src/doctor/rules/__init__.py
+++ b/src/doctor/rules/__init__.py
@@ -28,7 +28,7 @@ def is_rule_file(fname):
     """Check if file is a rules file."""
     if not isfile(fname):
         return False
-    if fname.endswith(['__init__.py', '_test.py']) or fname.startswith("test_"):
+    if fname.endswith(('__init__.py', '_test.py')) or fname.startswith("test_"):
         return False
     return True
 


### PR DESCRIPTION
When running from the source I was getting the following error:


```
$ PYTHONPATH=./src python -m doctor.cli mgd

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/adn/dev/timescale/doctor/src/doctor/cli.py", line 56, in <module>
    main()
  File "/Users/adn/dev/timescale/doctor/src/doctor/cli.py", line 50, in main
    load_rules()
  File "/Users/adn/dev/timescale/doctor/src/doctor/rules/__init__.py", line 39, in load_rules
    modules = [basename(f)[:-3] for f in pyfiles if is_rule_file(f)]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/adn/dev/timescale/doctor/src/doctor/rules/__init__.py", line 39, in <listcomp>
    modules = [basename(f)[:-3] for f in pyfiles if is_rule_file(f)]
                                                    ^^^^^^^^^^^^^^^
  File "/Users/adn/dev/timescale/doctor/src/doctor/rules/__init__.py", line 31, in is_rule_file
    if fname.endswith(['__init__.py', '_test.py']) or fname.startswith("test_"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: endswith first arg must be str or a tuple of str, not list
```

I added:

```
if __name__ == "__main__":
    main()
```

To `cli.py` to run it with `PYTHONPATH=./src python -m doctor.cli mgd`